### PR TITLE
Fix memory leak in QuickList

### DIFF
--- a/ActiveListExtensions/Utilities/QuickList.cs
+++ b/ActiveListExtensions/Utilities/QuickList.cs
@@ -51,7 +51,10 @@ namespace ActiveListExtensions.Utilities
 				throw new ArgumentOutOfRangeException(nameof(index));
 
 			if (index < _count - 1)
+			{
 				Array.Copy(_items, index + 1, _items, index, _count - index);
+				_items[_count - 1] = default(T);
+			}
 			else
 				_items[index] = default(T);
 

--- a/ActiveListExtensions/Utilities/QuickList.cs
+++ b/ActiveListExtensions/Utilities/QuickList.cs
@@ -51,7 +51,7 @@ namespace ActiveListExtensions.Utilities
 				throw new ArgumentOutOfRangeException(nameof(index));
 
 			if (index < _count)
-				Array.Copy(_items, index + 1, _items, index, _count - index - 1);
+				Array.Copy(_items, index + 1, _items, index, _count - index);
 			else
 				_items[index] = default(T);
 

--- a/ActiveListExtensions/Utilities/QuickList.cs
+++ b/ActiveListExtensions/Utilities/QuickList.cs
@@ -52,7 +52,7 @@ namespace ActiveListExtensions.Utilities
 
 			if (index < _count - 1)
 			{
-				Array.Copy(_items, index + 1, _items, index, _count - index);
+				Array.Copy(_items, index + 1, _items, index, _count - index - 1);
 				_items[_count - 1] = default(T);
 			}
 			else

--- a/ActiveListExtensions/Utilities/QuickList.cs
+++ b/ActiveListExtensions/Utilities/QuickList.cs
@@ -50,7 +50,7 @@ namespace ActiveListExtensions.Utilities
 			if (index < 0 || index >= Count)
 				throw new ArgumentOutOfRangeException(nameof(index));
 
-			if (index < _count)
+			if (index < _count - 1)
 				Array.Copy(_items, index + 1, _items, index, _count - index);
 			else
 				_items[index] = default(T);


### PR DESCRIPTION
When an element is removed from a QuickList, it wasn't properly moving the subsequent elements down and was holding on to a reference of the element indefinitely. This caused a memory leak because the QuickList would still be a GC root to the removed elements.